### PR TITLE
GitHub actions: cmake & clang-format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- STOP! Please verify that the issue you're reporting is not a security issue before you continue.
+
+Security issues must *never* be reported on GitHub Issues because GitHub Issues are public by default. A security issue, or vulnerability, may be any bug that represents a threat to the security of the ClamAV users or any issue that a malicious person could use to cause a Denial of Service (DoS) attack on a network service running ClamAV, such as a mail filter or file upload scanner.
+
+Read our Security Policy to find security issue reporting instructions: https://github.com/Cisco-Talos/clamav/security/policy
+If you are unsure if your bug is a security issue, please report it as a security issue. -->
+
+Describe the bug
+----------------
+
+Replace this text with a clear and concise description of the bug or feature request.
+
+How to reproduce the problem
+----------------------------
+
+Replace this text with specific steps needed to reproduce the issue.
+
+Attachments
+-----------
+
+If applicable, add screenshots to help explain your problem.
+
+<!-- CAUTION: Do not attach malware unless in an encrypted zip. Better yet, provide a link to the file on on VirusTotal.
+
+The maximum size for file attachments on GitHub Issues is 25MB and the maximum size for images is 10MB. If the file is too big, you can upload it to a password protected website and send us the URL and the credentials to access it.
+
+If your file must be kept confidential you can reach out on the [ClamAV Discord chat server](https://discord.gg/6vNAqWnVgw) to exchange email addresses and to share the zipped file, or to share the zip password. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://docs.clamav.net/Introduction.html#mailing-lists-and-chat
+    about: Questions should go to the mailing list

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,33 @@
+name: clang-format
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches:
+      - rel/*
+      - dev/*
+      - main
+  pull_request:
+    branches:
+      - rel/*
+      - dev/*
+      - main
+
+jobs:
+  formatting-check:
+    name: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - check: "libclambcc"
+            exclude: "(iana_cctld|bytecode_api_|bytecode_hooks|rijndael|yara|inffixed|inflate|queue|tomsfastmath|nsis|7z|regex|c++|generated)"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run clang-format style check for C/C++ programs.
+        uses: jidicula/clang-format-action@v3.4.0
+        with:
+          clang-format-version: "10"
+          check-path: ${{ matrix.path['check'] }}
+          exclude-regex: ${{ matrix.path['exclude'] }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,177 @@
+name: CMake Build
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches:
+      - rel/*
+      - dev/*
+      - main
+  pull_request:
+    branches:
+      - rel/*
+      - dev/*
+      - main
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  VCPKG_GIT_REF: 8a9a97315aefb3f8bc5d81bf66ca0025938b9c91
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Build Tools
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install wixtoolset clang
+
+      - name: Install pytest for easier to read test results
+        run: python3 -m pip install pytest
+
+      - uses: lukka/get-cmake@latest
+
+      # Restore from cache the previously built ports. If cache-miss, download, build vcpkg ports.
+      - name: Restore vcpkg ports from cache or install vcpkg
+        # Download and build vcpkg, without installing any port. If content is cached already, it is a no-op.
+        uses: lukka/run-vcpkg@v5
+        id: runvcpkg
+        with:
+          vcpkgArguments: "llvm"
+          vcpkgGitCommitId: "${{ env.VCPKG_GIT_REF }}"
+          vcpkgTriplet: "x64-windows"
+
+      - name: Print the VCPKG_ROOT & VCPKG_TRIPLET (for debugging)
+        shell: bash
+        run: echo "'${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}' '${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}' "
+
+      - name: dir the VCPKG_ROOT
+        run: dir ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}
+
+      - name: Create Build Directory
+        shell: bash
+        # Some projects don't allow in-source building, so create a separate build directory
+        # We'll use this as our working directory for all subsequent commands
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Run CMake+Ninja with triplet (cmd)
+        uses: lukka/run-cmake@main
+        id: runcmake_cmd
+        with:
+          cmakeGenerator: "Ninja" # Visual Studio 15 2017
+          cmakeListsOrSettingsJson: "CMakeListsTxtBasic"
+          cmakeListsTxtPath: "${{runner.workspace}}/clamav/CMakeLists.txt"
+          useVcpkgToolchainFile: true
+          cmakeAppendedArgs: '-A x64 -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DENABLE_EXAMPLES=ON -- -v'
+          cmakeBuildType: "${{ env.BUILD_TYPE }}"
+          vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
+          buildDirectory: "${{runner.workspace}}/build"
+
+      - name: Test
+        working-directory: ${{runner.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{ env.BUILD_TYPE }} -V
+
+      - name: Create Installer
+        working-directory: ${{runner.workspace}}/build
+        run: cpack -C ${{ env.BUILD_TYPE }}
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Dependencies
+        run: brew install llvm clang
+
+      - name: Install pytest for easier to read test results
+        run: python3 -m pip install pytest
+
+      - uses: lukka/get-cmake@latest
+
+      - name: Create Build Directory
+        shell: bash
+        # Some projects don't allow in-source building, so create a separate build directory
+        # We'll use this as our working directory for all subsequent commands
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        working-directory: ${{runner.workspace}}/build
+        # Note the current convention is to use the -S and -B options here to specify source
+        # and build directories, but this is only available with CMake 3.13 and higher.
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run:
+          cmake ${{runner.workspace}}/clamav -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DENABLE_EXAMPLES=ON
+
+      - name: Build
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        run: cmake --build . --config ${{ env.BUILD_TYPE }}
+
+      - name: Test
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{ env.BUILD_TYPE }} -V
+
+  build-ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Update package listings
+        run: sudo apt-get update
+
+      - name: Install Build Tools
+        run: sudo apt-get install -y bison flex valgrind
+
+      - name: Install Dependencies
+        run: sudo apt-get install -y llvm clang
+
+      - name: Install pytest for easier to read test results
+        run: python3 -m pip install pytest
+
+      - uses: lukka/get-cmake@latest
+
+      - name: Create Build Directory
+        shell: bash
+        # Some projects don't allow in-source building, so create a separate build directory
+        # We'll use this as our working directory for all subsequent commands
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        working-directory: ${{runner.workspace}}/build
+        # Note the current convention is to use the -S and -B options here to specify source
+        # and build directories, but this is only available with CMake 3.13 and higher.
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run:
+          cmake ${{runner.workspace}}/clamav -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DENABLE_EXAMPLES=ON
+
+      - name: Build
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        run: cmake --build . --config ${{ env.BUILD_TYPE }}
+
+      - name: Test
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{ env.BUILD_TYPE }} -V

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+# Citizen Code of Conduct
+
+## 1. Purpose
+
+A primary goal of the ClamAV community is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).  
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in ClamAV to help us create safe and positive experiences for everyone.
+
+## 2. Open [Source/Culture/Tech] Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+## 3. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+ * Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+ * Exercise consideration and respect in your speech and actions.
+ * Attempt collaboration before conflict.
+ * Refrain from demeaning, discriminatory, or harassing behavior and speech.
+ * Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+ * Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+## 4. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+ * Violence, threats of violence or violent language directed against another person.
+ * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+ * Posting or displaying sexually explicit or violent material.
+ * Posting or threatening to post other people's personally identifying information ("doxing").
+ * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+ * Inappropriate photography or recording.
+ * Inappropriate physical contact. You should have someone's consent before touching them.
+ * Unwelcome sexual attention. This includes, sexualized comments or jokes as well as inappropriate touching or unwelcomed sexual advances.
+ * Deliberate intimidation, stalking or following (online or in person).
+ * Advocating for, or encouraging, any of the above behavior.
+ * Sustained disruption of community events, including talks and presentations.
+
+## 5. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+## 6. Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. talos-external@cisco.com.
+
+Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+## 7. Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Cisco-Talos with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. 
+
+## 8. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
+
+This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
+
+## 9. Contact info
+
+talos-external@cisco.com
+
+## 10. License and attribution
+
+The Citizen Code of Conduct is distributed by Stumptown Syndicate under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+
+Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+_Revision 2.3. Posted 6 March 2017._
+
+_Revision 2.2. Posted 4 February 2016._
+
+_Revision 2.1. Posted 23 June 2014._
+
+_Revision 2.0, adopted by the Stumptown Syndicate board on 10 January 2013. Posted 17 March 2013._

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# ClamAV Security Policy
+
+If you are unsure if your bug is a security issue, please report it as a security issue.
+
+> `*`Bytecode signatures are cross-platform executable plugins. ClamAV will not load bytecode signatures unless they are signed by Cisco-Talos or the user has intentionally enabled unsigned bytecode signatures. Issues that require disabling this security mechanism and then loading unsigned bytecode signatures or loading unsigned bytecode signatures with the ClamBC signature testing tool are not considered to be vulnerabilities.
+
+## Vulnerability reporting best practices.
+
+Do **not** discuss the issue in a public forum, the project mailing lists, in chat, or anywhere else.
+
+Do **not** create a ticket on GitHub Issues. GitHub Issues are public. Submitting any information there on how to exploit ClamAV puts the ClamAV community at risk. If you do report a vulnerability via GitHub issues, your issue will be promptly removed.
+
+Submit your report by email to psirt@cisco.com. Support requests submitted to Cisco PSIRT that are received via email are typically acknowledged within 48 hours. PSIRT will provide you with additional information on how to proceed. Cisco PSIRT will work with the ClamAV developers to confirm or reject the security vulnerability.
+
+If the report is rejected, PSIRT or the ClamAV developers will write to you to explain why.
+
+If the report is accepted, the ClamAV team will craft a fix and may request your help to verify that you find it satisfactory. Cisco will assign a CVE ID and will work with you to identify a disclosure date when the CVE summary will become public and when it will be safe to discuss in public.
+
+Please allow us at least 90 days (about 3 months) to craft a fix and publish a security patch version with the fix before you tell anyone else about it. This non-disclosure window is critical to the security of your fellow ClamAV users and to the security of other products using libclamav.
+
+## How do I submit my vulnerability report?
+
+Security issues should be reported to Cisco PSIRT. The recommended method is to submit in email form to psirt@cisco.com. For details, see: https://tools.cisco.com/security/center/resources/security_vulnerability_policy.html
+
+## What should I include in my vulnerability report?
+
+Follow the same best practices for reporting a regular bug, but do not submit it on GitHub Issues! Instead, craft an email with the detailed report and attached files and submit it to psirt@cisco.com.
+
+First, verify that the bug exists in the latest stable patch release. This may not be the latest release provided by your package manager.
+
+At a minimum include the following:
+
+- Include step-by-step instructions for how to reproduce the issue.
+
+- If the issue is triggered by scanning a specific file, either:
+
+  - Include the file in an encrypted zip along with the password.
+
+  - Include instructions for how to generate a file that can be used to reproduce the issue.
+
+- Describe your working environment.


### PR DESCRIPTION
Add a basic cmake build & ctest action.
Add a clang-format action for the libclambcc directory.

Also adds a code of conduct, am issue template, and a security policy
based on the ones used by ClamAV.