### PR TITLE
Updated version information to 0.105

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ string(TIMESTAMP TODAY "%Y%m%d")
 set(VERSION_SUFFIX "-devel-${TODAY}")
 
 project( ClamBCC
-         VERSION "0.103.1"
+         VERSION "0.105.0"
          DESCRIPTION "ClamAV Bytecode Compiler." )
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
@@ -181,7 +181,7 @@ else()
     )
 endif()
 
-configure_file(clambc-version.h.in clambc-version.h)
+configure_file(clambc-version.h.in headers/clambc-version.h)
 
 #
 # Build targets!

--- a/clambcc/clambc-compiler.py
+++ b/clambcc/clambc-compiler.py
@@ -764,6 +764,24 @@ class ClamBCCOptionParser(OptionParser):
     def getPassthrough(self):
         return self.passthrough
 
+def printVersion():
+    compilerVersion = "Not written"
+    fileName = os.path.join("headers", "clambc-version.h")
+    if os.path.isfile(fileName):
+        f = open(fileName)
+        lines = f.readlines()
+        f.close()
+
+        for i in range(0, len(lines)):
+            line = lines[i].rstrip()
+            m = re.search('CLAMBC_VERSION "(.*)"', line)
+            if m:
+                compilerVersion = m.group(1)
+                break
+
+    #TODO: Print information for target version (after clamav installs the headers) 
+    print (f"ClamBC-Compiler {compilerVersion}")
+
 
 def main():
 
@@ -792,8 +810,7 @@ def main():
     (options, args) = parser.parse_args()
 
     if options.version:
-        #TODO: determine the version by calling into libclambcc.so
-        print('ClamBC-Compiler 0.103.1')
+        printVersion()
         sys.exit(0)
 
 

--- a/libclambcc/Common/version.c
+++ b/libclambcc/Common/version.c
@@ -1,4 +1,4 @@
-#include "clambc-version.h"
+#include "headers/clambc-version.h"
 
 const char *clambc_getversion(void)
 {


### PR DESCRIPTION
Updated version information to 0.105.  Read this information from
clambc-version.h, instead of hardcoding it.