### PR TITLE
Silence warnings related to _fail_missing_PE_HOOK_DECLAREor_PE_UNPACK…

### DIFF
--- a/headers/bytecode_local.h
+++ b/headers/bytecode_local.h
@@ -233,15 +233,15 @@ typedef struct signature {
  */
 /* some other macro may use __COUNTER__, so we need to subtract its current\
  * value to obtain zero-based indices */
-#define SIGNATURES_DEF_BEGIN                                                                               \
-    static const unsigned __signature_bias = __COUNTER__ + 1;                                              \
-    const struct __Signatures Signatures   = {/**                                                          \
-                                          \group_config                                                  \
-                                           * Defines the pattern for a previously declared subsignature. \
-                                           * @sa DECLARE_SIGNATURE                                       \
-                                           * @param name the name of a previously declared subsignature  \
-                                           * @param hex the pattern for this subsignature                \
-                                           */
+#define SIGNATURES_DEF_BEGIN                                                                             \
+    static const unsigned __signature_bias = __COUNTER__ + 1;                                            \
+    const struct __Signatures Signatures   = {/**                                                        \
+                                        \group_config                                                  \
+                                         * Defines the pattern for a previously declared subsignature. \
+                                         * @sa DECLARE_SIGNATURE                                       \
+                                         * @param name the name of a previously declared subsignature  \
+                                         * @param hex the pattern for this subsignature                \
+                                         */
 #define DEFINE_SIGNATURE(name, hex) \
     .name##_sig = (hex),            \
     .name       = {__COUNTER__ - __signature_bias},
@@ -545,7 +545,6 @@ static force_inline bool hasPEInfo(void)
             __fail_missing_PE_HOOK_DECLARE__or__PE_UNPACKER_DECLARE(); \
     }
 
-
 /**
 \group_pe
  * Returns whether this is a PE32+ executable.
@@ -553,7 +552,10 @@ static force_inline bool hasPEInfo(void)
  */
 static force_inline bool isPE64(void)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le16_to_host(__clambc_pedata.opt64.Magic) == 0x020b;
 }
 
@@ -834,7 +836,10 @@ static force_inline uint32_t getPELoaderFlags(void)
  */
 static force_inline uint16_t getPEMachine()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le16_to_host(__clambc_pedata.file_hdr.Machine);
 }
 
@@ -845,7 +850,10 @@ static force_inline uint16_t getPEMachine()
  */
 static force_inline uint32_t getPETimeDateStamp()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le32_to_host(__clambc_pedata.file_hdr.TimeDateStamp);
 }
 
@@ -856,7 +864,10 @@ static force_inline uint32_t getPETimeDateStamp()
  */
 static force_inline uint32_t getPEPointerToSymbolTable()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le32_to_host(__clambc_pedata.file_hdr.PointerToSymbolTable);
 }
 
@@ -867,7 +878,10 @@ static force_inline uint32_t getPEPointerToSymbolTable()
  */
 static force_inline uint32_t getPENumberOfSymbols()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le32_to_host(__clambc_pedata.file_hdr.NumberOfSymbols);
 }
 
@@ -878,7 +892,10 @@ static force_inline uint32_t getPENumberOfSymbols()
  */
 static force_inline uint16_t getPESizeOfOptionalHeader()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le16_to_host(__clambc_pedata.file_hdr.SizeOfOptionalHeader);
 }
 
@@ -889,7 +906,10 @@ static force_inline uint16_t getPESizeOfOptionalHeader()
  * @return characteristic of PE file, or 0 if not in PE hook*/
 static force_inline uint16_t getPECharacteristics()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le16_to_host(__clambc_pedata.file_hdr.Characteristics);
 }
 
@@ -913,7 +933,10 @@ static force_inline bool getPEisDLL()
  */
 static force_inline uint32_t getPEDataDirRVA(unsigned n)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     const struct pe_image_data_dir *p   = &__clambc_pedata.opt64_dirs[n];
     const struct pe_image_data_dir *p32 = &__clambc_pedata.opt32_dirs[n];
     return n < 16 ? le32_to_host(isPE64() ? p->VirtualAddress : p32->VirtualAddress)
@@ -928,7 +951,10 @@ static force_inline uint32_t getPEDataDirRVA(unsigned n)
  */
 static force_inline uint32_t getPEDataDirSize(unsigned n)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return n < 16 ? le32_to_host(isPE64() ? __clambc_pedata.opt64_dirs[n].Size : __clambc_pedata.opt32_dirs[n].Size)
                   : 0;
 }
@@ -951,7 +977,10 @@ static force_inline uint16_t getNumberOfSections(void)
  */
 static uint32_t getPELFANew(void)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le32_to_host(__clambc_pedata.e_lfanew);
 }
 
@@ -965,7 +994,10 @@ static uint32_t getPELFANew(void)
  */
 static force_inline int readPESectionName(unsigned char name[8], unsigned n)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     if (n >= getNumberOfSections())
         return -1;
     uint32_t at = getPELFANew() + sizeof(struct pe_image_file_hdr) + sizeof(struct pe_image_optional_hdr32);
@@ -1016,7 +1048,10 @@ static force_inline uint32_t getExeOffset(void)
  */
 static force_inline uint32_t getImageBase(void)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le32_to_host(__clambc_pedata.opt32.ImageBase);
 }
 
@@ -1027,7 +1062,10 @@ static force_inline uint32_t getImageBase(void)
  */
 static uint32_t getVirtualEntryPoint(void)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
     NEED_PE_INFO;
+#pragma GCC diagnostic pop
     return le32_to_host(isPE64() ? __clambc_pedata.opt64.AddressOfEntryPoint : __clambc_pedata.opt32.AddressOfEntryPoint);
 }
 

--- a/libclambcc/ClamBCAnalyzer/ClamBCAnalyzer.cpp
+++ b/libclambcc/ClamBCAnalyzer/ClamBCAnalyzer.cpp
@@ -76,8 +76,8 @@ bool ClamBCAnalyzer::runOnModule(Module &M)
     GlobalVariable *GVKind = M.getGlobalVariable("__clambc_kind");
     if (GVKind && GVKind->hasDefinitiveInitializer()) {
         kind = cast<ConstantInt>(GVKind->getInitializer())->getValue().getZExtValue();
-        //GVKind->setLinkage(GlobalValue::InternalLinkage);
-        //Do not set the linkage type to internal, because the optimizer will remove it.
+        // GVKind->setLinkage(GlobalValue::InternalLinkage);
+        // Do not set the linkage type to internal, because the optimizer will remove it.
         if (kind >= 65536) {
             ClamBCStop("Bytecode kind cannot be higher than 64k\n", &M);
         }
@@ -86,15 +86,15 @@ bool ClamBCAnalyzer::runOnModule(Module &M)
     GlobalVariable *G = M.getGlobalVariable("__Copyright");
     if (G && G->hasDefinitiveInitializer()) {
         Constant *C = G->getInitializer();
-        //std::string c;
+        // std::string c;
         StringRef c;
         if (!getConstantStringInfo(C, c)) {
             ClamBCStop("Failed to extract copyright string\n", &M);
         }
-        //copyright = strdup(c.c_str());
+        // copyright = strdup(c.c_str());
         copyright = c.str();
-        //G->setLinkage(GlobalValue::InternalLinkage);
-        //Do not set the linkage type to internal because the optimizer will remove it.
+        // G->setLinkage(GlobalValue::InternalLinkage);
+        // Do not set the linkage type to internal because the optimizer will remove it.
     }
 
     // Logical signature created by ClamBCLogicalCompiler.
@@ -105,7 +105,7 @@ bool ClamBCAnalyzer::runOnModule(Module &M)
     virusnames = Node ? cast<MDString>(Node->getOperand(0)->getOperand(0))->getString() : "";
 
     unsigned tid, fid;
-    //unsigned cid;
+    // unsigned cid;
     startTID = tid = clamav::initTypeIDs(typeIDs, M.getContext());
     // arrays of [2 x i8] .. [7 x i8] used for struct padding
     for (unsigned i = 1; i < 8; i++) {
@@ -116,7 +116,7 @@ bool ClamBCAnalyzer::runOnModule(Module &M)
     }
 
     std::vector<const Type *> types;
-    //cid=1;
+    // cid=1;
     fid = 1;
     for (Module::global_iterator I = M.global_begin(); I != M.global_end(); ++I) {
         GlobalVariable *gv = llvm::cast<GlobalVariable>(I);
@@ -129,7 +129,7 @@ bool ClamBCAnalyzer::runOnModule(Module &M)
          * can't use global idx 0 or 1 in the interpreter, since the size will
          * be incorrect in the interpreter.  Look at line 2011 of bytecode.c
          */
-        for (size_t loop = 0; loop < 2; loop++){
+        for (size_t loop = 0; loop < 2; loop++) {
             for (auto J : ces) {
                 ConstantExpr *CE = llvm::cast<ConstantExpr>(J);
                 // ClamAV bytecode doesn't support arbitrary constant expressions for
@@ -341,7 +341,7 @@ void ClamBCAnalyzer::printGlobals(uint16_t stid)
     llvm::Module &M = *pMod;
     // Describe types
     maxApi = 0;
-    //std::vector<const Function *> apis;
+    // std::vector<const Function *> apis;
     for (Module::iterator I = M.begin(), E = M.end(); I != E; ++I) {
         llvm::Function *pFunc = llvm::cast<llvm::Function>(I);
         // Skip dead declarations
@@ -403,8 +403,8 @@ void ClamBCAnalyzer::printGlobals(uint16_t stid)
         specialGlobals.insert(GV);
     }
 
-    //std::vector<Constant *> globalInits;
-    globalInits.push_back(0); //ConstantPointerNul placeholder
+    // std::vector<Constant *> globalInits;
+    globalInits.push_back(0); // ConstantPointerNul placeholder
     for (Module::global_iterator I = M.global_begin(), E = M.global_end(); I != E; ++I) {
         GlobalVariable *pgv = llvm::cast<GlobalVariable>(I);
         if (specialGlobals.count(pgv)) {
@@ -472,7 +472,7 @@ void ClamBCAnalyzer::printGlobals(uint16_t stid)
     }
 }
 
-//need to use bytecode_api_decl.c.h
+// need to use bytecode_api_decl.c.h
 void ClamBCAnalyzer::populateAPIMap()
 {
     unsigned id                          = 1;

--- a/libclambcc/ClamBCPrepareGEPsForWriter/ClamBCPrepareGEPsForWriter.cpp
+++ b/libclambcc/ClamBCPrepareGEPsForWriter/ClamBCPrepareGEPsForWriter.cpp
@@ -204,7 +204,7 @@ class ClamBCPrepareGEPsForWriter : public ModulePass
                     currType = llvm::cast<StructType>(tmp);
                 } else if (llvm::isa<ArrayType>(tmp)) {
                     currType = tmp;
-                } 
+                }
             } else if (ArrayType *pat = llvm::dyn_cast<ArrayType>(currType)) {
 
                 uint64_t size = getTypeSizeInBytes(pat->getArrayElementType());
@@ -218,7 +218,7 @@ class ClamBCPrepareGEPsForWriter : public ModulePass
                     currType = llvm::cast<StructType>(tmp);
                 } else if (llvm::isa<ArrayType>(tmp)) {
                     currType = tmp;
-                } 
+                }
 
             } else {
                 assert(0 && "Figure out what to do here");
@@ -324,7 +324,6 @@ class ClamBCPrepareGEPsForWriter : public ModulePass
 
         return pInst;
     }
-
 
     virtual void processGEPI(GetElementPtrInst *pgepi)
     {

--- a/libclambcc/ClamBCWriter/ClamBCWriter.cpp
+++ b/libclambcc/ClamBCWriter/ClamBCWriter.cpp
@@ -1050,7 +1050,7 @@ class ClamBCWriter : public ModulePass, public InstVisitor<ClamBCWriter>
 
         Function *pFunc = SI.getParent()->getParent();
         for (auto i = pFunc->arg_begin(), e = pFunc->arg_end(); i != e; i++) {
-            Argument * pArg = llvm::cast<Argument>(i);
+            Argument *pArg = llvm::cast<Argument>(i);
             if (pArg == V) {
                 printFixedNumber(OP_BC_COPY, 2);
                 printOperand(SI, SI.getOperand(0));


### PR DESCRIPTION
…ER_DECLARE

This missing function is used to fail the build if the user is calling a
PE support function without declaring PE_HOOK_DECLARE or
PE_UNPACKER_DECLARE.  This function is intentionally not defined.