### PR TITLE
Jenkins: update test pipeline path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ properties(
                        defaultValue: 'master',
                        description: 'tests-jenkins-shared-libraries branch'),
                 string(name: 'TEST_PIPELINE_PATH',
-                       defaultValue: 'bcc/test_bcc/',
+                       defaultValue: 'ClamBCC/test_bcc/',
                        description: 'path for test pipelines'),
 
             ]


### PR DESCRIPTION
We moved the pipeline within Jenkins to tidy up.
It accidentally broke the test pipeline.